### PR TITLE
Add Mongo options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ module.exports = {
   port: Env.get('MONGO_PORT', '27017'),
   user: Env.get('MONGO_USER', ''),
   pass: Env.get('MONGO_PASS', ''),
-  db: Env.get('MONGO_DATABASE', 'adonisjs')
+  db: Env.get('MONGO_DATABASE', 'adonisjs'),
+  options: Env.get('MONGO_OPTIONS', '')
 }
 ```
 *You are using a connection local without user and pass, leave it blank like on the example.*

--- a/providers/MongoritoProvider.js
+++ b/providers/MongoritoProvider.js
@@ -26,8 +26,7 @@ class MongoritoModel extends Mongorito.Model {
 class MongoritoProvider extends ServiceProvider {
 
   * register () {
-
-    const managers = this.app.getManagers();
+    const managers = this.app.getManagers()
 
     // Add Mongo auth support
     managers['Adonis/Src/AuthManager'].extend('MongoritoScheme', MongoritoScheme, 'scheme')
@@ -37,20 +36,22 @@ class MongoritoProvider extends ServiceProvider {
     }, 'serializer')
 
     this.app.singleton('Adonis/Addons/MongoritoModel', function (app) {
-
       const Config = app.use('Adonis/Src/Config')
       const mongoHost = Config.get('mongo.host')
       const mongoPort = Config.get('mongo.port')
       const mongoDb = Config.get('mongo.db')
       const mongoUser = Config.get('mongo.user', '')
       const mongoPass = Config.get('mongo.pass', '')
+      const mongoOptions = Config.get('mongo.options', '')
 
-      const connectUri = `${mongoHost}:${mongoPort}/${mongoDb}`
+      var connectUri = `${mongoHost}:${mongoPort}/${mongoDb}`
+      if (mongoOptions !== '') {
+        connectUri += '?' + mongoOptions
+      }
       const connectionString = (mongoUser !== '' || mongoPass !== '') ? `${mongoUser}:${mongoPass}@${connectUri}` : connectUri
 
       logger.verbose('connection string %s', connectionString)
       Mongorito.connect(connectionString)
-
 
       return MongoritoModel
     })


### PR DESCRIPTION
Before this commit there was no way to add mongo options to connectionString. For instance ?authSource=admin&replicaSet=rs0